### PR TITLE
fix: ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,4 +27,7 @@ module.exports = {
     // uncomment if you are using a builder like Babel
     "node/no-unsupported-features/es-syntax": "off",
   },
+  "parserOptions": {
+    "sourceType": "module"
+  },
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 12
   - 10
   - 8
-  - 6
 
 # Use containers.
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/


### PR DESCRIPTION
Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

See: https://stackoverflow.com/a/39173590/1123955